### PR TITLE
Bitstream download: completion-aware redirect, /500 fallback

### DIFF
--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -109,7 +109,7 @@ export class BitstreamDownloadPageComponent implements OnInit {
     const errorUrl = `${window.location.origin}/500`;
 
     // Use Angular HttpClient so auth interceptors, cookies and CSRF/XSRF tokens are applied consistently.
-    this.http.get(fileLink, {
+  this.http.get(fileLink, {
       observe: 'response',
       responseType: 'blob',
       withCredentials: true
@@ -143,8 +143,45 @@ export class BitstreamDownloadPageComponent implements OnInit {
         a.remove();
         setTimeout(() => URL.revokeObjectURL(url), 30_000);
 
-        // The network download has completed (blob received); safe to redirect now.
-        this.hardRedirectService.redirect(redirectUrl);
+        // The network download has completed (blob received). If a browser/system
+        // download dialog appears, many browsers blur the window and refocus when the
+        // dialog is closed. Use blur/focus as a generic signal of user interaction.
+        // If there's no blur shortly after the click, assume no dialog and redirect.
+        const noDialogFallbackMs = 1000;   // redirect if no blur occurs within 1s
+        const maxWaitMs = 120000;          // absolute cap to avoid waiting forever
+
+        let didBlur = false;
+        const onBlur = () => { didBlur = true; };
+        const onFocus = () => {
+          if (didBlur) {
+            cleanupAndRedirect();
+          }
+        };
+
+        const cleanup = () => {
+          window.removeEventListener('blur', onBlur);
+          window.removeEventListener('focus', onFocus);
+          clearTimeout(noDialogTimer);
+          clearTimeout(maxWaitTimer);
+        };
+
+        const cleanupAndRedirect = () => {
+          cleanup();
+          this.hardRedirectService.redirect(redirectUrl);
+        };
+
+        window.addEventListener('blur', onBlur);
+        window.addEventListener('focus', onFocus);
+
+        const noDialogTimer = setTimeout(() => {
+          if (!didBlur) {
+            cleanupAndRedirect();
+          }
+        }, noDialogFallbackMs);
+
+        const maxWaitTimer = setTimeout(() => {
+          cleanupAndRedirect();
+        }, maxWaitMs);
       },
       error: () => {
         // Simplified failure handling: redirect to error page on same origin

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -143,45 +143,10 @@ export class BitstreamDownloadPageComponent implements OnInit {
         a.remove();
         setTimeout(() => URL.revokeObjectURL(url), 30_000);
 
-        // The network download has completed (blob received). If a browser/system
-        // download dialog appears, many browsers blur the window and refocus when the
-        // dialog is closed. Use blur/focus as a generic signal of user interaction.
-        // If there's no blur shortly after the click, assume no dialog and redirect.
-        const noDialogFallbackMs = 1000;   // redirect if no blur occurs within 1s
-        const maxWaitMs = 120000;          // absolute cap to avoid waiting forever
-
-        let didBlur = false;
-        const onBlur = () => { didBlur = true; };
-        const onFocus = () => {
-          if (didBlur) {
-            cleanupAndRedirect();
-          }
-        };
-
-        const cleanup = () => {
-          window.removeEventListener('blur', onBlur);
-          window.removeEventListener('focus', onFocus);
-          clearTimeout(noDialogTimer);
-          clearTimeout(maxWaitTimer);
-        };
-
-        const cleanupAndRedirect = () => {
-          cleanup();
+        // Always redirect after a short delay, regardless of cancel/save
+        setTimeout(() => {
           this.hardRedirectService.redirect(redirectUrl);
-        };
-
-        window.addEventListener('blur', onBlur);
-        window.addEventListener('focus', onFocus);
-
-        const noDialogTimer = setTimeout(() => {
-          if (!didBlur) {
-            cleanupAndRedirect();
-          }
-        }, noDialogFallbackMs);
-
-        const maxWaitTimer = setTimeout(() => {
-          cleanupAndRedirect();
-        }, maxWaitMs);
+        }, 2000);
       },
       error: () => {
         // Simplified failure handling: redirect to error page on same origin

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -44,7 +44,7 @@ export class BitstreamDownloadPageComponent implements OnInit {
     private signpostingDataService: SignpostingDataService,
     private responseService: ServerResponseService,
     private halService: HALEndpointService,
-  private http: HttpClient,
+    private http: HttpClient,
     @Inject(PLATFORM_ID) protected platformId: string
   ) {
     this.initPageLinks();
@@ -85,8 +85,8 @@ export class BitstreamDownloadPageComponent implements OnInit {
       })
     ).subscribe(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
       if (isAuthorized && isLoggedIn && isNotEmpty(fileLink)) {
-        // Prefer a fetch+blob download so we know when the network download finished,
-        // then trigger save and redirect. Fallback to iframe for browsers that can't.
+        // Use HttpClient to retrieve the blob so we know the download finished,
+        // then trigger save and redirect. On failure, redirect to /500.
         this.downloadAndRedirect(fileLink);
       } else if (isAuthorized && !isLoggedIn) {
         this.hardRedirectService.redirect(bitstream._links.content.href);
@@ -101,12 +101,12 @@ export class BitstreamDownloadPageComponent implements OnInit {
   }
 
   /**
-   * Download a file via fetch so we can await completion, then trigger a save and redirect.
-   * Falls back to hidden iframe where fetch isn't possible or fails (e.g., CORS or very old Safari),
-   * and avoids redirecting immediately on Safari to prevent the download from being canceled.
+   * Download a file via HttpClient (await full blob) to detect completion, then trigger save and redirect.
+   * On any failure, redirect to the deployed site's /500 error page (same origin).
    */
   private downloadAndRedirect(fileLink: string): void {
     const redirectUrl = 'https://research.kuleuven.be/en/lirias/download-started';
+    const errorUrl = `${window.location.origin}/500`;
 
     // Use Angular HttpClient so auth interceptors, cookies and CSRF/XSRF tokens are applied consistently.
     this.http.get(fileLink, {
@@ -115,6 +115,11 @@ export class BitstreamDownloadPageComponent implements OnInit {
       withCredentials: true
     }).pipe(take(1)).subscribe({
       next: (resp: HttpResponse<Blob>) => {
+        // Validate body presence
+        if (!resp.body || !(resp.body instanceof Blob) || resp.body.size === 0) {
+          this.hardRedirectService.redirect(errorUrl);
+          return;
+        }
         // Extract filename from Content-Disposition
         const disposition = resp.headers.get('content-disposition') || '';
         let filename = 'download';
@@ -142,9 +147,8 @@ export class BitstreamDownloadPageComponent implements OnInit {
         this.hardRedirectService.redirect(redirectUrl);
       },
       error: () => {
-        // Generic fallback: navigate directly to the file URL so the browser manages the download.
-        // We skip the post-download redirect in fallback, prioritizing a successful download.
-        this.hardRedirectService.redirect(fileLink);
+        // Simplified failure handling: redirect to error page on same origin
+        this.hardRedirectService.redirect(errorUrl);
       }
     });
   }

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -109,7 +109,7 @@ export class BitstreamDownloadPageComponent implements OnInit {
     const errorUrl = `${window.location.origin}/500`;
 
     // Use Angular HttpClient so auth interceptors, cookies and CSRF/XSRF tokens are applied consistently.
-  this.http.get(fileLink, {
+    this.http.get(fileLink, {
       observe: 'response',
       responseType: 'blob',
       withCredentials: true
@@ -143,45 +143,8 @@ export class BitstreamDownloadPageComponent implements OnInit {
         a.remove();
         setTimeout(() => URL.revokeObjectURL(url), 30_000);
 
-        // The network download has completed (blob received). If a browser/system
-        // download dialog appears, many browsers blur the window and refocus when the
-        // dialog is closed. Use blur/focus as a generic signal of user interaction.
-        // If there's no blur shortly after the click, assume no dialog and redirect.
-        const noDialogFallbackMs = 1000;   // redirect if no blur occurs within 1s
-        const maxWaitMs = 120000;          // absolute cap to avoid waiting forever
-
-        let didBlur = false;
-        const onBlur = () => { didBlur = true; };
-        const onFocus = () => {
-          if (didBlur) {
-            cleanupAndRedirect();
-          }
-        };
-
-        const cleanup = () => {
-          window.removeEventListener('blur', onBlur);
-          window.removeEventListener('focus', onFocus);
-          clearTimeout(noDialogTimer);
-          clearTimeout(maxWaitTimer);
-        };
-
-        const cleanupAndRedirect = () => {
-          cleanup();
-          this.hardRedirectService.redirect(redirectUrl);
-        };
-
-        window.addEventListener('blur', onBlur);
-        window.addEventListener('focus', onFocus);
-
-        const noDialogTimer = setTimeout(() => {
-          if (!didBlur) {
-            cleanupAndRedirect();
-          }
-        }, noDialogFallbackMs);
-
-        const maxWaitTimer = setTimeout(() => {
-          cleanupAndRedirect();
-        }, maxWaitMs);
+        // The network download has completed (blob received); safe to redirect now.
+        this.hardRedirectService.redirect(redirectUrl);
       },
       error: () => {
         // Simplified failure handling: redirect to error page on same origin

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -44,7 +44,7 @@ export class BitstreamDownloadPageComponent implements OnInit {
     private signpostingDataService: SignpostingDataService,
     private responseService: ServerResponseService,
     private halService: HALEndpointService,
-    private http: HttpClient,
+  private http: HttpClient,
     @Inject(PLATFORM_ID) protected platformId: string
   ) {
     this.initPageLinks();
@@ -85,8 +85,8 @@ export class BitstreamDownloadPageComponent implements OnInit {
       })
     ).subscribe(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
       if (isAuthorized && isLoggedIn && isNotEmpty(fileLink)) {
-        // Use HttpClient to retrieve the blob so we know the download finished,
-        // then trigger save and redirect. On failure, redirect to /500.
+        // Prefer a fetch+blob download so we know when the network download finished,
+        // then trigger save and redirect. Fallback to iframe for browsers that can't.
         this.downloadAndRedirect(fileLink);
       } else if (isAuthorized && !isLoggedIn) {
         this.hardRedirectService.redirect(bitstream._links.content.href);
@@ -101,12 +101,12 @@ export class BitstreamDownloadPageComponent implements OnInit {
   }
 
   /**
-   * Download a file via HttpClient (await full blob) to detect completion, then trigger save and redirect.
-   * On any failure, redirect to the deployed site's /500 error page (same origin).
+   * Download a file via fetch so we can await completion, then trigger a save and redirect.
+   * Falls back to hidden iframe where fetch isn't possible or fails (e.g., CORS or very old Safari),
+   * and avoids redirecting immediately on Safari to prevent the download from being canceled.
    */
   private downloadAndRedirect(fileLink: string): void {
     const redirectUrl = 'https://research.kuleuven.be/en/lirias/download-started';
-    const errorUrl = `${window.location.origin}/500`;
 
     // Use Angular HttpClient so auth interceptors, cookies and CSRF/XSRF tokens are applied consistently.
     this.http.get(fileLink, {
@@ -115,11 +115,6 @@ export class BitstreamDownloadPageComponent implements OnInit {
       withCredentials: true
     }).pipe(take(1)).subscribe({
       next: (resp: HttpResponse<Blob>) => {
-        // Validate body presence
-        if (!resp.body || !(resp.body instanceof Blob) || resp.body.size === 0) {
-          this.hardRedirectService.redirect(errorUrl);
-          return;
-        }
         // Extract filename from Content-Disposition
         const disposition = resp.headers.get('content-disposition') || '';
         let filename = 'download';
@@ -147,8 +142,9 @@ export class BitstreamDownloadPageComponent implements OnInit {
         this.hardRedirectService.redirect(redirectUrl);
       },
       error: () => {
-        // Simplified failure handling: redirect to error page on same origin
-        this.hardRedirectService.redirect(errorUrl);
+        // Generic fallback: navigate directly to the file URL so the browser manages the download.
+        // We skip the post-download redirect in fallback, prioritizing a successful download.
+        this.hardRedirectService.redirect(fileLink);
       }
     });
   }

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -13,7 +13,6 @@ import { HardRedirectService } from '../../core/services/hard-redirect.service';
 import { getForbiddenRoute } from '../../app-routing-paths';
 import { RemoteData } from '../../core/data/remote-data';
 import { isPlatformServer, Location } from '@angular/common';
-import { HttpClient, HttpResponse } from '@angular/common/http';
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 import { SignpostingDataService } from '../../core/data/signposting-data.service';
 import { ServerResponseService } from '../../core/services/server-response.service';
@@ -44,7 +43,6 @@ export class BitstreamDownloadPageComponent implements OnInit {
     private signpostingDataService: SignpostingDataService,
     private responseService: ServerResponseService,
     private halService: HALEndpointService,
-  private http: HttpClient,
     @Inject(PLATFORM_ID) protected platformId: string
   ) {
     this.initPageLinks();
@@ -85,9 +83,13 @@ export class BitstreamDownloadPageComponent implements OnInit {
       })
     ).subscribe(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
       if (isAuthorized && isLoggedIn && isNotEmpty(fileLink)) {
-        // Prefer a fetch+blob download so we know when the network download finished,
-        // then trigger save and redirect. Fallback to iframe for browsers that can't.
-        this.downloadAndRedirect(fileLink);
+        const iframe = document.createElement('iframe');
+        iframe.src = fileLink;
+        document.body.appendChild(iframe);
+        // Delay slightly to ensure download starts before redirect
+        setTimeout(() => {
+          this.hardRedirectService.redirect('https://research.kuleuven.be/en/lirias/download-started');
+        }, 1000); // Adjust delay as needed
       } else if (isAuthorized && !isLoggedIn) {
         this.hardRedirectService.redirect(bitstream._links.content.href);
       } else if (!isAuthorized && isLoggedIn) {
@@ -96,55 +98,6 @@ export class BitstreamDownloadPageComponent implements OnInit {
         this.route.paramMap.subscribe((map) => {
           this.hardRedirectService.redirect(this.halService.getRootHref() + "/core/bitstreams/" + map.get('id') + '/content');
         });
-      }
-    });
-  }
-
-  /**
-   * Download a file via fetch so we can await completion, then trigger a save and redirect.
-   * Falls back to hidden iframe where fetch isn't possible or fails (e.g., CORS or very old Safari),
-   * and avoids redirecting immediately on Safari to prevent the download from being canceled.
-   */
-  private downloadAndRedirect(fileLink: string): void {
-    const redirectUrl = 'https://research.kuleuven.be/en/lirias/download-started';
-
-    // Use Angular HttpClient so auth interceptors, cookies and CSRF/XSRF tokens are applied consistently.
-    this.http.get(fileLink, {
-      observe: 'response',
-      responseType: 'blob',
-      withCredentials: true
-    }).pipe(take(1)).subscribe({
-      next: (resp: HttpResponse<Blob>) => {
-        // Extract filename from Content-Disposition
-        const disposition = resp.headers.get('content-disposition') || '';
-        let filename = 'download';
-        const fnameStar = disposition.match(/filename\*=(?:UTF-8''|)([^;\n]+)/i);
-        const fname = disposition.match(/filename=\"?([^\";\n]+)\"?/i);
-        if (fnameStar && fnameStar[1]) {
-          try { filename = decodeURIComponent(fnameStar[1]); } catch { filename = fnameStar[1]; }
-        } else if (fname && fname[1]) {
-          filename = fname[1];
-        }
-
-        const blob = resp.body as Blob;
-        const url = URL.createObjectURL(blob);
-
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = filename;
-        a.style.display = 'none';
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        setTimeout(() => URL.revokeObjectURL(url), 30_000);
-
-        // The network download has completed (blob received); safe to redirect now.
-        this.hardRedirectService.redirect(redirectUrl);
-      },
-      error: () => {
-        // Generic fallback: navigate directly to the file URL so the browser manages the download.
-        // We skip the post-download redirect in fallback, prioritizing a successful download.
-        this.hardRedirectService.redirect(fileLink);
       }
     });
   }

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -143,10 +143,45 @@ export class BitstreamDownloadPageComponent implements OnInit {
         a.remove();
         setTimeout(() => URL.revokeObjectURL(url), 30_000);
 
-        // Always redirect after a short delay, regardless of cancel/save
-        setTimeout(() => {
+        // The network download has completed (blob received). If a browser/system
+        // download dialog appears, many browsers blur the window and refocus when the
+        // dialog is closed. Use blur/focus as a generic signal of user interaction.
+        // If there's no blur shortly after the click, assume no dialog and redirect.
+        const noDialogFallbackMs = 1000;   // redirect if no blur occurs within 1s
+        const maxWaitMs = 120000;          // absolute cap to avoid waiting forever
+
+        let didBlur = false;
+        const onBlur = () => { didBlur = true; };
+        const onFocus = () => {
+          if (didBlur) {
+            cleanupAndRedirect();
+          }
+        };
+
+        const cleanup = () => {
+          window.removeEventListener('blur', onBlur);
+          window.removeEventListener('focus', onFocus);
+          clearTimeout(noDialogTimer);
+          clearTimeout(maxWaitTimer);
+        };
+
+        const cleanupAndRedirect = () => {
+          cleanup();
           this.hardRedirectService.redirect(redirectUrl);
-        }, 2000);
+        };
+
+        window.addEventListener('blur', onBlur);
+        window.addEventListener('focus', onFocus);
+
+        const noDialogTimer = setTimeout(() => {
+          if (!didBlur) {
+            cleanupAndRedirect();
+          }
+        }, noDialogFallbackMs);
+
+        const maxWaitTimer = setTimeout(() => {
+          cleanupAndRedirect();
+        }, maxWaitMs);
       },
       error: () => {
         // Simplified failure handling: redirect to error page on same origin

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -83,13 +83,7 @@ export class BitstreamDownloadPageComponent implements OnInit {
       })
     ).subscribe(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
       if (isAuthorized && isLoggedIn && isNotEmpty(fileLink)) {
-        const iframe = document.createElement('iframe');
-        iframe.src = fileLink;
-        document.body.appendChild(iframe);
-        // Delay slightly to ensure download starts before redirect
-        setTimeout(() => {
-          this.hardRedirectService.redirect('https://research.kuleuven.be/en/lirias/download-started');
-        }, 1000); // Adjust delay as needed
+        this.hardRedirectService.redirect(fileLink);
       } else if (isAuthorized && !isLoggedIn) {
         this.hardRedirectService.redirect(bitstream._links.content.href);
       } else if (!isAuthorized && isLoggedIn) {

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -13,6 +13,7 @@ import { HardRedirectService } from '../../core/services/hard-redirect.service';
 import { getForbiddenRoute } from '../../app-routing-paths';
 import { RemoteData } from '../../core/data/remote-data';
 import { isPlatformServer, Location } from '@angular/common';
+import { HttpClient, HttpResponse } from '@angular/common/http';
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 import { SignpostingDataService } from '../../core/data/signposting-data.service';
 import { ServerResponseService } from '../../core/services/server-response.service';
@@ -43,6 +44,7 @@ export class BitstreamDownloadPageComponent implements OnInit {
     private signpostingDataService: SignpostingDataService,
     private responseService: ServerResponseService,
     private halService: HALEndpointService,
+  private http: HttpClient,
     @Inject(PLATFORM_ID) protected platformId: string
   ) {
     this.initPageLinks();
@@ -83,13 +85,9 @@ export class BitstreamDownloadPageComponent implements OnInit {
       })
     ).subscribe(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
       if (isAuthorized && isLoggedIn && isNotEmpty(fileLink)) {
-        const iframe = document.createElement('iframe');
-        iframe.src = fileLink;
-        document.body.appendChild(iframe);
-        // Delay slightly to ensure download starts before redirect
-        setTimeout(() => {
-          this.hardRedirectService.redirect('https://research.kuleuven.be/en/lirias/download-started');
-        }, 1000); // Adjust delay as needed
+        // Prefer a fetch+blob download so we know when the network download finished,
+        // then trigger save and redirect. Fallback to iframe for browsers that can't.
+        this.downloadAndRedirect(fileLink);
       } else if (isAuthorized && !isLoggedIn) {
         this.hardRedirectService.redirect(bitstream._links.content.href);
       } else if (!isAuthorized && isLoggedIn) {
@@ -98,6 +96,55 @@ export class BitstreamDownloadPageComponent implements OnInit {
         this.route.paramMap.subscribe((map) => {
           this.hardRedirectService.redirect(this.halService.getRootHref() + "/core/bitstreams/" + map.get('id') + '/content');
         });
+      }
+    });
+  }
+
+  /**
+   * Download a file via fetch so we can await completion, then trigger a save and redirect.
+   * Falls back to hidden iframe where fetch isn't possible or fails (e.g., CORS or very old Safari),
+   * and avoids redirecting immediately on Safari to prevent the download from being canceled.
+   */
+  private downloadAndRedirect(fileLink: string): void {
+    const redirectUrl = 'https://research.kuleuven.be/en/lirias/download-started';
+
+    // Use Angular HttpClient so auth interceptors, cookies and CSRF/XSRF tokens are applied consistently.
+    this.http.get(fileLink, {
+      observe: 'response',
+      responseType: 'blob',
+      withCredentials: true
+    }).pipe(take(1)).subscribe({
+      next: (resp: HttpResponse<Blob>) => {
+        // Extract filename from Content-Disposition
+        const disposition = resp.headers.get('content-disposition') || '';
+        let filename = 'download';
+        const fnameStar = disposition.match(/filename\*=(?:UTF-8''|)([^;\n]+)/i);
+        const fname = disposition.match(/filename=\"?([^\";\n]+)\"?/i);
+        if (fnameStar && fnameStar[1]) {
+          try { filename = decodeURIComponent(fnameStar[1]); } catch { filename = fnameStar[1]; }
+        } else if (fname && fname[1]) {
+          filename = fname[1];
+        }
+
+        const blob = resp.body as Blob;
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 30_000);
+
+        // The network download has completed (blob received); safe to redirect now.
+        this.hardRedirectService.redirect(redirectUrl);
+      },
+      error: () => {
+        // Generic fallback: navigate directly to the file URL so the browser manages the download.
+        // We skip the post-download redirect in fallback, prioritizing a successful download.
+        this.hardRedirectService.redirect(fileLink);
       }
     });
   }


### PR DESCRIPTION
# PR: Bitstream download flow — completion-aware redirect, auth-safe, and user-dialog aware

Author: @ErykKul
Date: 2025-08-19
Target repo/branch: libis/lirias-dspace-angular (head: lirias-test)
Base for review: review-base-2025-08-19-precursor (snapshot of lirias-test before today’s 3 commits)
Compare link: https://github.com/libis/lirias-dspace-angular/compare/review-base-2025-08-19-precursor...lirias-test

## Summary
This PR improves the bitstream download experience and reliability:
- Uses Angular HttpClient with `responseType: 'blob'` and `withCredentials` to ensure auth interceptors and cookies are applied.
- Triggers file save via an object URL and only redirects to the thank-you page after the blob is received (network download complete).
- Detects potential browser/system download dialogs generically using `window` blur/focus events to wait for user interaction before redirecting.
- Simplifies failure handling: on any error or empty blob, redirect to same-origin `/500`.
- Removes iframe/timing hacks and browser-specific branches to avoid Safari issues and redirect loops.

## Motivation
The previous approach used an iframe and a fixed timeout, which caused issues in Safari and could redirect too early, interrupting the download. We also needed a way to know when a download actually started or when the user had interacted with any native dialogs.

## Changes
- Component: `src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts`
  - Replace iframe + `setTimeout` with `HttpClient.get(..., { responseType: 'blob', withCredentials, observe: 'response' })`.
  - Extract filename from `Content-Disposition` when present.
  - Save via a temporary `<a>` tag with object URL; revoke after a short delay.
  - Redirect to `https://research.kuleuven.be/en/lirias/download-started` only after successful blob receipt.
  - Wait for possible download dialogs using blur/focus (redirect after focus returns if a blur happened; otherwise redirect shortly; hard cap 2 minutes).
  - Failure path: redirect to `${window.location.origin}/500` to avoid loops.
  - Clean up comments and formatting.

## Commits in scope
- cc39cc417 — feat(bitstream-download-page): detect download completion with HttpClient blob before redirect
- 81eee814b — refactor(bitstream-download-page): use HttpClient blob for download completion and simplify failure handling
- 0d7019ce9 — feat(bitstream-download-page): wait for user interaction via blur/focus when download dialogs appear

Base commit before these: 15aab3c9f290

## Testing
- Authenticated user with access:
  - Navigate to a bitstream download page.
  - Confirm file downloads and then the app redirects to the thank-you page.
- Dialog behavior:
  - For files that trigger native app/download dialogs, verify the page waits until focus returns before redirecting.
  - For files that don’t show dialogs, redirect should occur ~1s after download click.
- Failure path:
  - Simulate network error or block the request; verify redirect to same-origin `/500` without loops.
- Cross-browser smoke test: Chrome, Firefox, Safari.

## Risk / Mitigations
- Memory: Blob approach buffers in memory. For very large files we may need a streaming solution (e.g., StreamSaver + Service Worker). Out of scope for this PR.
- Dialog detection is heuristic (blur/focus). It is browser-agnostic but not guaranteed for all setups; a safety max-wait avoids hanging.
- Failure redirect uses same-origin `/500` for environment-agnostic behavior. If a fixed FQDN is desired, we can switch to a configured base URL.

## AI Assistance Disclosure
This PR was drafted with AI assistance (GitHub Copilot). All changes were reviewed and committed by @ErykKul. Commit messages include explicit AI assistance disclosure.

## Prompts used (verbatim)
1. this part is giving us problems in safari browsers:```        // Delay slightly to ensure download starts before redirect
        setTimeout(() => {
          this.hardRedirectService.redirect('https://research.kuleuven.be/en/lirias/download-started');
        }, 1000); // Adjust delay as needed```. Propose a better solution, preferably that can detect when the file finished downloading, and only after that it redirects to 'https://research.kuleuven.be/en/lirias/download-started' (See <attachments> above for file contents. You may not need to search or read the file again.)
2. Try not to have any safari specific code; make it work for all browsers the same way. Make sure the download still works; the frontend does add authentication and authorization information in the code as it was implemented, otherwise the download will not work. This is also the reason why we publish links to this download page instead of publishing direct link to the document; the frontend makes sure the user is authenticated with shibboleth, it queries the backend for access rights, packages all information needed for the backend to process the request correctly.
3. write a commit message that also discloses ai assitance in this commit
4. commit using that message
5. I have noticed a possible infinite loop, the fallback to the fileLink. The problem is that the links we publish are for the backend only, if the file is not public, we redirect to the download page on the frontend that manages the authentication and authorization. If the frontend redirects back to the filelink, we will have an infinite redirect loop. (See <attachments> above for file contents. You may not need to search or read the file again.)
6. Simplify and redirect to https://lirias2test.libis.kuleuven.be/500 if anything fails. Replace the fdqn with the actual one as deployed, following the examples from this file.
7. formatting of the code looks off. try formatting it to look as the rest does.
8. commit with a good message and disclose ai assistence
9. I had Nick test it on test. This was for a word file. He says the thank you page is too quick to be able to click on download in this instance. But that was for a word file.
10. can you detect that the case where there is a browser download dialog? Instead of a delay, it would be better to wait until the user did the necessary actions, and then redirect. Do not make that file or browser specific.
11. commit this change
12. how to do a review of the changes we did today?
13. we did the work on lirias-test, maybe we need to create a new branch with how lirias test looked like before our last three changes, do a pr from this branch to that new branch, the pr would be the review possibility. Execute that plan, if possible.
14. I am creating the PR, it worked. Give me a short title for that PR.
15. I have added ai-transition repo to this workspace. Create temp/pr.md file with the pr description as described in the rules of ai-transition. Remember to list all of the prompts I did in this conversations and add them in the description. My github username is ErykKul.

## Reviewer checklist
- [ ] Download completes and thank-you redirect works only after blob receipt.
- [ ] Dialog wait works: page waits on blur/focus; immediate redirect when no blur.
- [ ] Failure path redirects to same-origin `/500` with no loops.
- [ ] No Safari-specific logic; behavior is consistent across browsers.
- [ ] Code style matches surrounding code; no lint/type errors.

## Rollback plan
Revert the three commits above or reset `lirias-test` to `review-base-2025-08-19-precursor` if needed.
